### PR TITLE
correction typo error

### DIFF
--- a/pygmtsar/pygmtsar/SBAS_dem.py
+++ b/pygmtsar/pygmtsar/SBAS_dem.py
@@ -181,7 +181,7 @@ class SBAS_dem(SBAS_reframe):
             print ('Note: method argument is deprecated, just omit it')
 
         if product == 'SRTM1':
-            resolution = '03s'
+            resolution = '01s'
         elif product == 'SRTM3':
             resolution = '03s'
         elif product in ['01s', '03s']:


### PR DESCRIPTION
Hello,
I have noticed an error in a section of your code and would like to suggest a correction in [SBAS_dem.py](https://github.com/mobigroup/gmtsar/blob/ebaf7a577b5ffbd0201bc0861a43d5fe7158f2db/pygmtsar/pygmtsar/SBAS_dem.py#L184)

if product == 'SRTM1':
    resolution = '03s'
to

if product == 'SRTM1':
    resolution = '01s'
Thanks.